### PR TITLE
 Added a timeout option onMousLeave

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ See [Demo page][github-page]
 | border       | PropTypes.string                                    | Tooltip border color               | "#000"    |
 | color        | PropTypes.string                                    | Tooltip text color                 | "#fff"    |
 | content      | PropTypes.any.isRequired                            | Tooltip content                    | -         |
+| exitTimeout  | PropTypes.number                                    | Persistence, in milliseconds       | 0         |
 | fadeDuration | PropTypes.number                                    | Fade duration, in milliseconds     | 0         |
 | fadeEasing   | PropTypes.string                                    | Fade easing                        | "linear"  |
 | fixed        | PropTypes.bool                                      | Tooltip behavior, hover by default | false     |

--- a/demo/src/routes.js
+++ b/demo/src/routes.js
@@ -34,6 +34,26 @@ const routes = [
     label: "Demo",
   },
   {
+    path: "/timeout",
+    exact: true,
+    demo: {
+      component: (
+        <ReactSimpleTooltip
+          exitTimeout={1000}
+          placement="top"
+          content="😎"
+          arrow={15}
+        >
+          <Zone>Hover me !</Zone>
+        </ReactSimpleTooltip>
+      ),
+      displayName: "ReactSimpleTooltip",
+      hiddenProps: ["children"],
+      html: demoHtml,
+    },
+    label: "Timeout",
+  },
+  {
     path: "/standalone",
     demo: {
       component: (

--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -7,6 +7,7 @@ exports[`Tooltip Should render without children 1`] = `
   border="#000"
   color="#fff"
   content="my content"
+  exitTimeout={0}
   fadeDuration={0}
   fadeEasing="linear"
   fixed={false}
@@ -18,7 +19,9 @@ exports[`Tooltip Should render without children 1`] = `
   radius={0}
   zIndex={1}
 >
-  <styled.div>
+  <styled.div
+    exitTimeout={0}
+  >
     <div
       className="sc-gZMcBi daZGjV"
     >
@@ -94,6 +97,7 @@ exports[`Tooltip should render 1`] = `
   border="#000"
   color="#fff"
   content="my content"
+  exitTimeout={0}
   fadeDuration={0}
   fadeEasing="linear"
   fixed={false}
@@ -106,6 +110,7 @@ exports[`Tooltip should render 1`] = `
   zIndex={1}
 >
   <styled.div
+    exitTimeout={0}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
   >

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,8 @@ import Tooltip from "./components/Tooltip"
 import Bubble from "./components/Bubble"
 import {easingPropType} from "./utils/propTypes"
 
+/*eslint-env browser*/
+
 const Container = styled.div`
   position: relative;
   display: inline-block;
@@ -29,7 +31,14 @@ class Wrapper extends React.Component {
   }
 
   handleMouseLeave() {
-    this.setState({open: false})
+    const {exitTimeout} = this.props
+    if (exitTimeout) {
+      setTimeout(() => {
+        this.setState({open: false})
+      }, 1000)
+    } else {
+      this.setState({open: false})
+    }
   }
 
   render() {
@@ -105,6 +114,7 @@ Wrapper.propTypes = {
   children: PropTypes.any,
   color: PropTypes.string,
   content: PropTypes.any.isRequired,
+  exitTimeout: PropTypes.number,
   fadeDuration: PropTypes.number,
   fadeEasing: easingPropType,
   fixed: PropTypes.bool,
@@ -123,6 +133,7 @@ Wrapper.defaultProps = {
   border: "#000",
   children: null,
   color: "#fff",
+  exitTimeout: 0,
   fadeDuration: 0,
   fadeEasing: "linear",
   fixed: false,

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -3,6 +3,10 @@ import React from "react"
 import Tooltip from "./index"
 import TooltipElement from "./components/Tooltip"
 
+/*eslint-env browser*/
+
+jest.useFakeTimers()
+
 describe("Tooltip", () => {
   const render = props =>
     mount(
@@ -58,5 +62,41 @@ describe("Tooltip", () => {
     // Expect the tooltip to be closed
     expect(wrapper.state("open")).toEqual(false)
     expect(toolTip.prop("open")).toEqual(false)
+  })
+
+  it("should open when user hovers and close when the mouse leaves, after the timeout", () => {
+    const exitTimeout = 1000
+    const wrapper = render({exitTimeout})
+    const container = wrapper
+      .findWhere(n => typeof n.prop("onMouseEnter") === "function")
+      .first()
+    const toolTip = wrapper.find(TooltipElement)
+
+    // Expect tooltip to be closed by default
+    expect(wrapper.state("open")).toEqual(false)
+    expect(toolTip.prop("open")).toEqual(false)
+
+    // Simulate a mouse enter event
+    container.simulate("mouseEnter")
+    wrapper.update()
+
+    // Expect the tooltip to be open
+    expect(wrapper.state("open")).toEqual(true)
+    expect(toolTip.prop("open")).toEqual(true)
+
+    // Simulate a mouse leave event
+    container.simulate("mouseLeave")
+    wrapper.update()
+
+    // Expect the tooltip not to be closed
+    expect(wrapper.state("open")).toEqual(true)
+    expect(toolTip.prop("open")).toEqual(true)
+
+    // Expect that the timeout was called once, with the duration
+    expect(setTimeout).toHaveBeenCalledTimes(1)
+    expect(setTimeout).toHaveBeenLastCalledWith(
+      expect.any(Function),
+      exitTimeout
+    )
   })
 })


### PR DESCRIPTION
Hi, thank you for this cool Tooltip component !

I'd like to add a feature where you can specify a timeout duration so then tooltip doesn't close instantly.

In my case the Tooltip contains some UI you can click on, without timeout it's really hard to actually get to click on the content, you have to move the mouse before the Tooltip get unmounted.

Let me know if there is anything wrong.

Cheers,

Adrien